### PR TITLE
Bugfix: no-unused-vars & no-empty-object-type

### DIFF
--- a/src/components/common/typography.jsx
+++ b/src/components/common/typography.jsx
@@ -14,7 +14,11 @@ export function MarkdownText({ className, children }) {
 			className={className}
 			remarkPlugins={[[remarkGfm, { singleTilde: false }]]}
 			components={{
-                p: ({ node, ...props }) => <Twemoji options={{ className: "twemoji" }}>{props.children}</Twemoji>,
+                p: ({ ...props }) => (
+					<Twemoji options={{ className: "twemoji" }}>
+						{props.children}
+					</Twemoji>
+				),
             }}
 		>
 			{children}

--- a/src/components/main/tools/emojis/sections.jsx
+++ b/src/components/main/tools/emojis/sections.jsx
@@ -32,7 +32,7 @@ export function EmojiToolUtilSection({ useSubgroup, setUseSubgroup, ...props }) 
 			navigator.clipboard.writeText(preview);
 			toast(generateToastObject("info", "Copied to clipboard!"));
 		} catch (error) {
-			toast(generateToastObject("warning", "Copied to clipboard!"));
+			toast(generateToastObject("warning", error.message));
 		}
 	}
 

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface InputProps
-	extends React.InputHTMLAttributes<HTMLInputElement> { }
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
 	({ className, type, ...props }, ref) => {

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-	extends React.TextareaHTMLAttributes<HTMLTextAreaElement> { }
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
 	({ className, ...props }, ref) => {

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -18,12 +18,12 @@ type ToasterToast = ToastProps & {
 	action?: ToastActionElement
 }
 
-const actionTypes = {
-	ADD_TOAST: "ADD_TOAST",
-	UPDATE_TOAST: "UPDATE_TOAST",
-	DISMISS_TOAST: "DISMISS_TOAST",
-	REMOVE_TOAST: "REMOVE_TOAST",
-} as const
+enum ActionTypes {
+	ADD_TOAST = "ADD_TOAST",
+	UPDATE_TOAST = "UPDATE_TOAST",
+	DISMISS_TOAST = "DISMISS_TOAST",
+	REMOVE_TOAST = "REMOVE_TOAST",
+}
 
 let count = 0
 
@@ -32,23 +32,21 @@ function genId() {
 	return count.toString()
 }
 
-type ActionType = typeof actionTypes
-
 type Action =
 	| {
-		type: ActionType["ADD_TOAST"]
+		type: ActionTypes.ADD_TOAST
 		toast: ToasterToast
 	}
 	| {
-		type: ActionType["UPDATE_TOAST"]
+		type: ActionTypes.UPDATE_TOAST
 		toast: Partial<ToasterToast>
 	}
 	| {
-		type: ActionType["DISMISS_TOAST"]
+		type: ActionTypes.DISMISS_TOAST
 		toastId?: ToasterToast["id"]
 	}
 	| {
-		type: ActionType["REMOVE_TOAST"]
+		type: ActionTypes.REMOVE_TOAST
 		toastId?: ToasterToast["id"]
 	}
 
@@ -66,7 +64,7 @@ const addToRemoveQueue = (toastId: string) => {
 	const timeout = setTimeout(() => {
 		toastTimeouts.delete(toastId)
 		dispatch({
-			type: "REMOVE_TOAST",
+			type: ActionTypes.REMOVE_TOAST,
 			toastId: toastId,
 		})
 	}, TOAST_REMOVE_DELAY)
@@ -76,13 +74,13 @@ const addToRemoveQueue = (toastId: string) => {
 
 export const reducer = (state: State, action: Action): State => {
 	switch (action.type) {
-		case "ADD_TOAST":
+		case ActionTypes.ADD_TOAST:
 			return {
 				...state,
 				toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
 			}
 
-		case "UPDATE_TOAST":
+		case ActionTypes.UPDATE_TOAST:
 			return {
 				...state,
 				toasts: state.toasts.map((t) =>
@@ -90,7 +88,7 @@ export const reducer = (state: State, action: Action): State => {
 				),
 			}
 
-		case "DISMISS_TOAST": {
+		case ActionTypes.DISMISS_TOAST: {
 			const { toastId } = action
 
 			// ! Side effects ! - This could be extracted into a dismissToast() action,
@@ -115,7 +113,7 @@ export const reducer = (state: State, action: Action): State => {
 				),
 			}
 		}
-		case "REMOVE_TOAST":
+		case ActionTypes.REMOVE_TOAST:
 			if (action.toastId === undefined) {
 				return {
 					...state,
@@ -147,13 +145,13 @@ function toast({ ...props }: Toast) {
 
 	const update = (props: ToasterToast) =>
 		dispatch({
-			type: "UPDATE_TOAST",
+			type: ActionTypes.UPDATE_TOAST,
 			toast: { ...props, id },
 		})
-	const dismiss = () => dispatch({ type: "DISMISS_TOAST", toastId: id })
+	const dismiss = () => dispatch({ type: ActionTypes.DISMISS_TOAST, toastId: id })
 
 	dispatch({
-		type: "ADD_TOAST",
+		type: ActionTypes.ADD_TOAST,
 		toast: {
 			...props,
 			id,
@@ -187,7 +185,7 @@ function useToast() {
 	return {
 		...state,
 		toast,
-		dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
+		dismiss: (toastId?: string) => dispatch({ type: ActionTypes.DISMISS_TOAST, toastId }),
 	}
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,6 @@
 			"styles/*": ["./src/app/styles/*"],
 		}
 	},
-	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "src/app/layout.js", "src/app/page.js", "src/lib/providers.js", "src/lib/utils.js", "src/components/common/theme-toggle.jsx", "src/app/sitemap.js", "src/lib/cron-utils.js", "src/components/main/tools/emojis/emoji-group.jsx"],
+	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "src/**/*.js", "src/**/*.jsx"],
 	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
Bugfix of the following errors:
```
Failed to compile.
./src/components/common/typography.jsx
17:23  Error: 'node' is defined but never used.  @typescript-eslint/no-unused-vars
./src/components/main/tools/emojis/emoji-group.jsx
73:50  Warning: The ref value 'ref.current' will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by React, copy 'ref.current' to a variable inside the effect, and use that variable in the cleanup function.  react-hooks/exhaustive-deps
./src/components/main/tools/emojis/sections.jsx
34:12  Error: 'error' is defined but never used.  @typescript-eslint/no-unused-vars
./src/components/ui/input.tsx
5:18  Error: An interface declaring no members is equivalent to its supertype.  @typescript-eslint/no-empty-object-type
./src/components/ui/textarea.tsx
5:18  Error: An interface declaring no members is equivalent to its supertype.  @typescript-eslint/no-empty-object-type
./src/hooks/use-toast.ts
21:7  Error: 'actionTypes' is assigned a value but only used as a type.  @typescript-eslint/no-unused-vars
info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/basic-features/eslint#disabling-rules
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Command "yarn run build" exited with 1
```